### PR TITLE
Implement piano dimension calculation required by game play

### DIFF
--- a/src/components/DuetRoom.tsx
+++ b/src/components/DuetRoom.tsx
@@ -1,7 +1,6 @@
 import { makeStyles } from '@material-ui/core';
 import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { PlayerInfo } from '../types/PlayerInfo';
 import { RoomInfo } from '../types/RoomInfo';
 import {
   calculateDefaultPianoDimension,
@@ -38,7 +37,8 @@ const DuetRoom: React.FC<{ maybeRoomId: string | null; isCreate: boolean }> = ({
   const { width, height } = useWindowDimensions();
   const keyboardDimension = calculateDefaultPianoDimension(width);
   const keyHeight = calculateKeyHeight(height);
-  const getFriendId = (players: PlayerInfo[], myId: number) => {
+  const getFriendId = (roomState: RoomInfo, myId: number) => {
+    const players = roomState.players;
     if (!players) {
       return null;
     }
@@ -77,7 +77,7 @@ const DuetRoom: React.FC<{ maybeRoomId: string | null; isCreate: boolean }> = ({
       <PlayerContext.Provider
         value={{
           me: playerId,
-          friend: getFriendId(roomState.players, playerId),
+          friend: getFriendId(roomState, playerId),
         }}
       >
         <RoomHeader />

--- a/src/components/DuetRoom.tsx
+++ b/src/components/DuetRoom.tsx
@@ -4,9 +4,8 @@ import { useHistory } from 'react-router-dom';
 import { PlayerInfo } from '../types/PlayerInfo';
 import { RoomInfo } from '../types/RoomInfo';
 import {
-  calculateKeyboardRange,
-  calculateKeyWidth,
-  calculateStartNote,
+  calculateDefaultPianoDimension,
+  calculateKeyHeight,
 } from '../utils/calculateKeyboardDimension';
 import socket, {
   addListeners,
@@ -36,9 +35,9 @@ const DuetRoom: React.FC<{ maybeRoomId: string | null; isCreate: boolean }> = ({
   const [roomState, setRoomState] = useState({} as RoomInfo);
   const [playerId, setPlayerId] = useState(-1);
 
-  const { width } = useWindowDimensions();
-  const keyWidth = calculateKeyWidth(width);
-  const range = calculateKeyboardRange(width);
+  const { width, height } = useWindowDimensions();
+  const keyboardDimension = calculateDefaultPianoDimension(width);
+  const keyHeight = calculateKeyHeight(height);
   const getFriendId = (players: PlayerInfo[], myId: number) => {
     if (!players) {
       return null;
@@ -84,9 +83,8 @@ const DuetRoom: React.FC<{ maybeRoomId: string | null; isCreate: boolean }> = ({
         <RoomHeader />
         <div className={classes.piano}>
           <InteractivePiano
-            start={calculateStartNote(range)}
-            range={range}
-            keyWidth={keyWidth}
+            {...keyboardDimension}
+            keyHeight={keyHeight}
             didPlayNote={(note, playedBy) => {
               if (playerId === playedBy) {
                 playNote(note);

--- a/src/components/InteractivePiano.tsx
+++ b/src/components/InteractivePiano.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Piano from './Piano/Piano';
 import PianoContainer from './Piano/PianoContainer';
 import OctaveShiftKey from './Piano/OctaveShiftKey';
-import getKeyboardShortcutsMapping from '../utils/getKeyboardShorcutsMapping';
+import { getKeyboardMapping } from '../utils/getKeyboardShorcutsMapping';
 import './InteractivePiano.css';
 import { useTheme, useMediaQuery } from '@material-ui/core';
 
@@ -10,6 +10,8 @@ type Props = {
   start: number;
   range: number;
   keyWidth: number;
+  keyHeight: number;
+  keyboardMap?: { [key: string]: number };
   didPlayNote: (key: number, playerId: number) => void;
   didStopNote: (key: number, playerId: number) => void;
 };
@@ -18,6 +20,8 @@ const InteractivePiano: React.FC<Props> = ({
   start,
   range,
   keyWidth,
+  keyHeight,
+  keyboardMap,
   didPlayNote,
   didStopNote,
 }) => {
@@ -26,6 +30,10 @@ const InteractivePiano: React.FC<Props> = ({
 
   const lowestMidiNote = 21;
   const highestMidiNote = 108;
+
+  useEffect(() => {
+    setStartNote(start);
+  }, [start]);
 
   const shiftDownOctave = () => {
     let newStartNote = Math.max(startNote - 12, lowestMidiNote);
@@ -46,12 +54,15 @@ const InteractivePiano: React.FC<Props> = ({
 
   const theme = useTheme();
   const isDesktopView = useMediaQuery(theme.breakpoints.up('md'));
-  const keyboardMap = getKeyboardShortcutsMapping(startNote, range);
+  const defaultKeyboardMap = isDesktopView
+    ? getKeyboardMapping(startNote, range)
+    : {};
 
   return (
     <PianoContainer>
       <OctaveShiftKey
         type="left"
+        keyHeight={keyHeight}
         onClick={shiftDownOctave}
         disabled={startNote === lowestMidiNote}
       />
@@ -59,12 +70,14 @@ const InteractivePiano: React.FC<Props> = ({
         startNote={startNote}
         endNote={endNote}
         keyWidth={keyWidth}
-        keyboardMap={isDesktopView ? keyboardMap : {}}
+        keyHeight={keyHeight}
+        keyboardMap={keyboardMap ? keyboardMap : defaultKeyboardMap}
         didPlayNote={didPlayNote}
         didStopNote={didStopNote}
       />
       <OctaveShiftKey
         type="right"
+        keyHeight={keyHeight}
         onClick={shiftUpOctave}
         disabled={endNote === highestMidiNote}
       />

--- a/src/components/Piano/OctaveShiftKey.tsx
+++ b/src/components/Piano/OctaveShiftKey.tsx
@@ -3,11 +3,10 @@ import { makeStyles } from '@material-ui/core';
 import '../InteractivePiano.css';
 import ChevronLeftIcon from '../../icons/ChevronRightIcon';
 import ChevronRightIcon from '../../icons/ChevronLeftIcon';
-import { calculateKeyHeight } from '../../utils/calculateKeyboardDimension';
-import useWindowDimensions from '../../utils/useWindowDimensions';
 
 type Props = {
   type: string;
+  keyHeight: number;
   onClick: () => void;
   disabled: boolean;
 };
@@ -23,10 +22,13 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const OctaveShiftKey: React.FC<Props> = ({ type, onClick, disabled }) => {
+const OctaveShiftKey: React.FC<Props> = ({
+  type,
+  keyHeight,
+  onClick,
+  disabled,
+}) => {
   const classes = useStyles();
-  const { height } = useWindowDimensions();
-  const keyHeight = calculateKeyHeight(height);
   const Icon = icons[type];
 
   return (

--- a/src/components/Piano/Piano.tsx
+++ b/src/components/Piano/Piano.tsx
@@ -3,8 +3,6 @@ import PianoKey from './PianoKey';
 import { PlayerContext } from '../PlayerContext';
 import getNotesBetween from './utils/getNotesBetween';
 import getKeyboardShortcutForNote from './utils/getKeyboardShortcutsForNote';
-import useWindowDimensions from '../../utils/useWindowDimensions';
-import { calculateKeyHeight } from '../../utils/calculateKeyboardDimension';
 import '../InteractivePiano.css';
 import { PlayingNote } from '../../types/PlayingNote';
 import InstrumentAudio from './InstrumentAudio';
@@ -14,6 +12,7 @@ type Props = {
   startNote: number;
   endNote: number;
   keyWidth: number;
+  keyHeight: number;
   keyboardMap: { [key: string]: number };
   didPlayNote: (note: number, playerId: number) => void;
   didStopNote: (note: number, playerId: number) => void;
@@ -27,12 +26,11 @@ const Piano: React.FC<Props> = ({
   startNote,
   endNote,
   keyWidth,
+  keyHeight,
   keyboardMap,
   didPlayNote,
   didStopNote,
 }) => {
-  const { height } = useWindowDimensions();
-  const keyHeight = calculateKeyHeight(height);
   const notes = getNotesBetween(startNote, endNote);
   const { me, friend } = useContext(PlayerContext);
   const [playingNotes, setPlayingNotes] = useState<PlayingNote[]>([]);
@@ -138,21 +136,25 @@ const Piano: React.FC<Props> = ({
     event.stopPropagation();
     setUseTouchEvents(true);
     setTouchedNotes(getTouchedNotes(event.touches));
+    console.log(`(Parent) Mouch start ${Array.from(touchedNotes.toString())}`);
   };
 
   const handleTouchEnd = (event: React.TouchEvent<HTMLDivElement>) => {
     event.stopPropagation();
     setTouchedNotes(getTouchedNotes(event.touches));
+    console.log(`(Parent) Mouch end ${Array.from(touchedNotes).toString()}`);
   };
 
   const handleTouchCancel = (event: React.TouchEvent<HTMLDivElement>) => {
     event.stopPropagation();
     setTouchedNotes(getTouchedNotes(event.touches));
+    console.log(`(Parent) Mouch cancel ${Array.from(touchedNotes).toString()}`);
   };
 
   const handleTouchMove = (event: React.TouchEvent<HTMLDivElement>) => {
     event.stopPropagation();
     setTouchedNotes(getTouchedNotes(event.touches));
+    console.log(`(Parent) Mouch move ${Array.from(touchedNotes).toString()}`);
   };
 
   const getTouchedNotes = (touches: React.TouchList) => {

--- a/src/components/Piano/PianoKey.tsx
+++ b/src/components/Piano/PianoKey.tsx
@@ -33,14 +33,14 @@ const PianoKey: React.FC<Props> = ({
   const [useTouchEvents, setUseTouchEvents] = useState(useTouchscreen);
 
   const handleMouseDown = (event: MouseEvent) => {
-    console.log(`Mouse down ${note}`);
+    // console.log(`Mouse down ${note}`);
     event.preventDefault();
     event.stopPropagation();
     startPlayingNote();
   };
 
   const handleMouseUp = (event: MouseEvent) => {
-    console.log(`Mouse up ${note}`);
+    // console.log(`Mouse up ${note}`);
     event.stopPropagation();
     stopPlayingNote();
   };
@@ -48,7 +48,7 @@ const PianoKey: React.FC<Props> = ({
   const handleMouseEnter = (event: MouseEvent) => {
     event.stopPropagation();
     if (event.buttons) {
-      console.log(`Mouse enter ${note}`);
+      // console.log(`Mouse enter ${note}`);
       startPlayingNote();
     }
   };
@@ -56,14 +56,14 @@ const PianoKey: React.FC<Props> = ({
   const handleMouseLeave = (event: MouseEvent) => {
     event.stopPropagation();
     if (event.buttons) {
-      console.log(`Mouse leave ${note}`);
+      // console.log(`Mouse leave ${note}`);
       stopPlayingNote();
     }
   };
 
   // Event bubbling starts from here (bubble touch event to parent)
   const handleTouchStart = () => {
-    console.log(`(Child) Touch start ${note}`);
+    // console.log(`(Child) Touch start ${note}`);
     setUseTouchEvents(true);
   };
 

--- a/src/components/Piano/PianoKey.tsx
+++ b/src/components/Piano/PianoKey.tsx
@@ -33,14 +33,14 @@ const PianoKey: React.FC<Props> = ({
   const [useTouchEvents, setUseTouchEvents] = useState(useTouchscreen);
 
   const handleMouseDown = (event: MouseEvent) => {
-    // console.log(`Mouse down ${note}`);
+    console.log(`Mouse down ${note}`);
     event.preventDefault();
     event.stopPropagation();
     startPlayingNote();
   };
 
   const handleMouseUp = (event: MouseEvent) => {
-    // console.log(`Mouse up ${note}`);
+    console.log(`Mouse up ${note}`);
     event.stopPropagation();
     stopPlayingNote();
   };
@@ -48,7 +48,7 @@ const PianoKey: React.FC<Props> = ({
   const handleMouseEnter = (event: MouseEvent) => {
     event.stopPropagation();
     if (event.buttons) {
-      // console.log(`Mouse enter ${note}`);
+      console.log(`Mouse enter ${note}`);
       startPlayingNote();
     }
   };
@@ -56,14 +56,14 @@ const PianoKey: React.FC<Props> = ({
   const handleMouseLeave = (event: MouseEvent) => {
     event.stopPropagation();
     if (event.buttons) {
-      // console.log(`Mouse leave ${note}`);
+      console.log(`Mouse leave ${note}`);
       stopPlayingNote();
     }
   };
 
   // Event bubbling starts from here (bubble touch event to parent)
   const handleTouchStart = () => {
-    // console.log(`(Child) Touch start ${note}`);
+    console.log(`(Child) Touch start ${note}`);
     setUseTouchEvents(true);
   };
 

--- a/src/pages/Solo.tsx
+++ b/src/pages/Solo.tsx
@@ -2,21 +2,20 @@ import React from 'react';
 import InteractivePiano from '../components/InteractivePiano';
 import RoomHeader from '../components/RoomHeader';
 import {
-  calculateKeyboardRange,
-  calculateKeyWidth,
-  calculateStartNote,
+  calculateDefaultPianoDimension, calculateKeyHeight
 } from '../utils/calculateKeyboardDimension';
 import useWindowDimensions from '../utils/useWindowDimensions';
 
 const Solo: React.FC = () => {
-  const { width } = useWindowDimensions();
-  const keyWidth = calculateKeyWidth(width);
-  const range = calculateKeyboardRange(width);
+  const { width, height } = useWindowDimensions();
+  const keyboardDimension = calculateDefaultPianoDimension(width)
+  const keyHeight = calculateKeyHeight(height);
   const piano = (
     <InteractivePiano
-      start={calculateStartNote(range)}
-      range={range}
-      keyWidth={keyWidth}
+      {
+      ...keyboardDimension
+      }
+      keyHeight={keyHeight}
       didPlayNote={(note, playerId) => {
         // console.log(`Start playing: ${note} by ${playerId}`);
       }}

--- a/src/utils/calculateKeyboardDimension.tsx
+++ b/src/utils/calculateKeyboardDimension.tsx
@@ -1,3 +1,5 @@
+import isAccidentalNote from '../components/Piano/utils/isAccidentalNote';
+
 const totalKeyMargin = 0; // Fixed, once updated, update the css as well
 const octaveShiftKeyWidth = 30; // Fixed, once updated, update the css as well
 const referenceCenterNote = 60; // C4
@@ -5,35 +7,138 @@ const minRange = 24; // 2 Octaves
 const referenceKeywidth = 50;
 const octageRange = 12;
 
-/* CASUAL MODE */
+/********************* DEFAULT MODE **************************************/
+/* Before game play */
 /* Assumption: startNote is always C */
-export function calculateKeyboardRange(totalWidth: number): number {
+function calculateKeyboardRange(totalWidth: number): number {
   const keyboardWidth = calculateKeyboardWidth(totalWidth);
   const maxOctaves = calculateMaxOctaves(keyboardWidth);
   return Math.max(calculateRange(maxOctaves), minRange);
 }
 
-export function calculateKeyWidth(totalWidth: number): number {
+function calculateKeyWidth(totalWidth: number): number {
   const keyboardWidth = calculateKeyboardWidth(totalWidth);
   const octaves = calculateNumberOfOctaves(calculateKeyboardRange(totalWidth));
   return keyboardWidth / (octaves * 7) - totalKeyMargin;
 }
 
-export function calculateStartNote(range: number): number {
+// Try to center referenceCenterNote (C4)
+function calculateStartNote(range: number): number {
   const octaves = calculateNumberOfOctaves(range);
   // If odd octaves, show one more higher octave
   return referenceCenterNote - calculateRange(Math.floor(octaves / 2));
 }
 
-function calculateMaxOctaves(keyboardWidth: number): number {
-  // Try to fit in as many octaves as possible
-  return Math.floor(keyboardWidth / (referenceKeywidth + totalKeyMargin) / 7);
+// Returns the { start, range, keyWidth }
+export function calculateDefaultPianoDimension(totalWidth: number) {
+  const range = calculateKeyboardRange(totalWidth);
+  return {
+    start: calculateStartNote(range),
+    range: range,
+    keyWidth: calculateKeyWidth(totalWidth),
+  };
 }
 
-/* GAME MODE */
-/* Start note might not be C */
+/******************************* GAME MODE ******************************/
 
-/* HELPERS */
+/******************  Desktop **********************/
+/* Assume regularStartNote is C */
+/* RegularStartNote is the first mapped note on the screen */
+/* At least 3 octaves on screen */
+
+function calculateKeyboardRangeWithRegularStartNote(
+  totalWidth: number,
+  startNote: number
+) {
+  const keyboardWidth = calculateKeyboardWidth(totalWidth);
+  const maxOctaves = calculateMaxOctaves(keyboardWidth);
+  return Math.max(
+    Math.min(108 - startNote, calculateRange(maxOctaves)),
+    minRange
+  );
+}
+
+function calculateKeyWidthWithRegularStartNote(
+  totalWidth: number,
+  range: number
+) {
+  const keyboardWidth = calculateKeyboardWidth(totalWidth);
+  const octaves = calculateNumberOfOctaves(range);
+  return keyboardWidth / (octaves * 7) - totalKeyMargin;
+}
+
+function calculateStartNoteWithRegularStartNote(
+  totalWidth: number,
+  regularStartNote: number
+) {
+  const keyboardWidth = calculateKeyboardWidth(totalWidth);
+  const maxOctaves = calculateMaxOctaves(keyboardWidth);
+  if (maxOctaves === 7) {
+    return 24;
+  } else if (maxOctaves === 6) {
+    return Math.max(24, regularStartNote - 24);
+  } else if (maxOctaves === 5 || maxOctaves === 4) {
+    return Math.max(24, regularStartNote - 12);
+  } else {
+    return regularStartNote;
+  }
+}
+
+/******************  Mobile **********************/
+/* SmallStartNote might not be C */
+/* SmallStartNote is the leftmost key on the screen (which is the actual start note) */
+/* Exactly 2 octaves */
+function calculateKeyWidthWithSmallStartNote(
+  totalWidth: number,
+  smallStartNote: number
+) {
+  const keyboardWidth = calculateKeyboardWidth(totalWidth);
+  const range = calculateKeyboardRangeWithRegularStartNote(
+    totalWidth,
+    smallStartNote
+  );
+  let whiteKeys = 0;
+  for (let i = 0; i < range; i++) {
+    if (!isAccidentalNote(smallStartNote + i)) {
+      whiteKeys += 1;
+    }
+  }
+  return keyboardWidth / whiteKeys - totalKeyMargin;
+}
+
+/******************  Overall **********************/
+// Returns the { start, range, keyWidth }
+export function calculateGamePianoDimension(
+  totalWidth: number,
+  smallStartNote: number,
+  regularStartNote: number
+) {
+  if (calculateMaxOctaves(calculateKeyboardWidth(totalWidth)) <= 2) {
+    // Use small start note
+    return {
+      start: smallStartNote,
+      range: 24,
+      keyWidth: calculateKeyWidthWithSmallStartNote(totalWidth, smallStartNote),
+    };
+  } else {
+    // Use regular start note
+    const startNote = calculateStartNoteWithRegularStartNote(
+      totalWidth,
+      regularStartNote
+    );
+    const range = calculateKeyboardRangeWithRegularStartNote(
+      totalWidth,
+      startNote
+    );
+    return {
+      start: startNote,
+      range: range,
+      keyWidth: calculateKeyWidthWithRegularStartNote(totalWidth, range),
+    };
+  }
+}
+
+/******************************* HELPERS ******************************/
 function calculateKeyboardWidth(totalWidth: number): number {
   return totalWidth - octaveShiftKeyWidth * 2;
 }
@@ -58,4 +163,9 @@ function calculateNumberOfOctaves(range: number): number {
 
 function calculateRange(octaves: number): number {
   return octaves * octageRange;
+}
+
+function calculateMaxOctaves(keyboardWidth: number): number {
+  // Fit in as many octaves as possible
+  return Math.floor(keyboardWidth / (referenceKeywidth + totalKeyMargin) / 7);
 }

--- a/src/utils/calculateKeyboardDimension.tsx
+++ b/src/utils/calculateKeyboardDimension.tsx
@@ -138,6 +138,31 @@ export function calculateGamePianoDimension(
   }
 }
 
+export function getOffsetMap(
+  startNote: number,
+  range: number,
+  keyWidth: number
+) {
+  let currOffset = 0;
+  let map: { [note: number]: number } = {};
+  map[startNote] = 0;
+  for (let i = 1; i < range; i += 1) {
+    // If previous key is black key
+    if (isAccidentalNote(startNote + i - 1)) {
+      currOffset += calculateBlackKeyWidth(keyWidth) / 2;
+    } else {
+      // If previous is white and current is black
+      if (isAccidentalNote(startNote + i)) {
+        currOffset += keyWidth - calculateBlackKeyWidth(keyWidth) / 2;
+      } else {
+        currOffset += keyWidth;
+      }
+    }
+    map[startNote + i] = currOffset;
+  }
+  return map;
+}
+
 /******************************* HELPERS ******************************/
 function calculateKeyboardWidth(totalWidth: number): number {
   return totalWidth - octaveShiftKeyWidth * 2;

--- a/src/utils/getKeyboardShorcutsMapping.tsx
+++ b/src/utils/getKeyboardShorcutsMapping.tsx
@@ -31,11 +31,13 @@ const shortcuts = [
   ['['],
 ];
 
-export default function getKeyboardShortcutsMapping(
-  startNote: number,
+// CASUAL MODE
+// Always center the mappings
+export function getKeyboardMapping(
+  startNote: number, // the leftmost note on screen
   range: number
 ): { [key: string]: number } {
-  let firstMappedKey = startNote;
+  let firstMappedNote = startNote;
   let offset = 0;
   // If start note is not C, find the next C
   if (startNote % 12 !== 0) {
@@ -45,13 +47,32 @@ export default function getKeyboardShortcutsMapping(
   if (range > 30) {
     offset += Math.floor(range / 12 / 2 - 1) * 12;
   }
-  firstMappedKey += offset;
+  firstMappedNote += offset;
 
   const mapRange = Math.min(30, range - offset);
   const map: { [key: string]: number } = {};
   for (let i = 0; i < mapRange; i++) {
     const shortcutKeys = shortcuts[i];
-    const note = firstMappedKey + i;
+    const note = firstMappedNote + i;
+    shortcutKeys.forEach(shortcut => {
+      map[shortcut] = note;
+    });
+  }
+  return map;
+}
+
+// GAME MODE (desktop view)
+// Assume the start note and first mapped note are both C here
+export function getKeyboardMappingWithSpecificStart(
+  firstMappedNote: number,
+  startNote: number,
+  range: number
+): { [key: string]: number } {
+  const mapRange = Math.min(30, range - (firstMappedNote - startNote));
+  const map: { [key: string]: number } = {};
+  for (let i = 0; i < mapRange; i++) {
+    const shortcutKeys = shortcuts[i];
+    const note = firstMappedNote + i;
     shortcutKeys.forEach(shortcut => {
       map[shortcut] = note;
     });

--- a/src/utils/getKeyboardShorcutsMapping.tsx
+++ b/src/utils/getKeyboardShorcutsMapping.tsx
@@ -31,7 +31,7 @@ const shortcuts = [
   ['['],
 ];
 
-// CASUAL MODE
+// DEFAULT MODE
 // Always center the mappings
 export function getKeyboardMapping(
   startNote: number, // the leftmost note on screen
@@ -61,7 +61,7 @@ export function getKeyboardMapping(
   return map;
 }
 
-// GAME MODE (desktop view)
+// GAME MODE (desktop view only)
 // Assume the start note and first mapped note are both C here
 export function getKeyboardMappingWithSpecificStart(
   firstMappedNote: number,


### PR DESCRIPTION
Default mode:
`calculateDefaultPianoDimension`: take in screen width and return { startNote, range, keyWidth }

Game mode:
`calculateGamePianoDimension`: take in screen width, small start note and regular start node and return  { startNote, range, keyWidth }

`keyHeight` can be obtained from `calculateKeyboardWidth(screenWidth)`
NOTE: keyWidth refers to the white key width, can use this method to obtain the black key width `calculateBlackKeyWidth(whiteKeyWidth: number): number`