### PR TITLE
Add progress bar

### DIFF
--- a/src/components/Duet/DuetRoomHeader.tsx
+++ b/src/components/Duet/DuetRoomHeader.tsx
@@ -15,6 +15,7 @@ import PlayerIcon from '../../icons/PlayerIcon';
 import SettingsIcon from '../../icons/SettingsIcon';
 import { updateReady } from '../../utils/socket';
 import useSong from '../../utils/useSong';
+import ProgressBar from '../ProgressBar';
 import RoomHeader from '../shared/RoomHeader';
 
 const useStyles = makeStyles(theme => ({
@@ -24,12 +25,12 @@ const useStyles = makeStyles(theme => ({
   settingIcon: {
     marginLeft: theme.spacing(1),
   },
-
   link: {
     color: '#0000EE',
   },
-  empty: {
+  progressBar: {
     flexGrow: 1,
+    marginRight: theme.spacing(1),
   },
   roomId: {
     marginRight: theme.spacing(1),
@@ -138,7 +139,10 @@ const DuetRoomHeader: React.FC<Props> = ({ view, setView }) => {
     <RoomHeader>
       {backButton()}
       {centerComponents()}
-      <Box component="span" className={classes.empty} />
+      {/* TODO: Change to actual timing */}
+      <div className={classes.progressBar}>
+        {view === 'solo.play' && <ProgressBar duration={126} started={false} />}
+      </div>
       {roomDetails()}
       <IconButton edge="end" size="small" className={classes.settingIcon}>
         <SettingsIcon />

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react';
+import {
+  createStyles,
+  makeStyles,
+  Theme,
+  withStyles,
+} from '@material-ui/core/styles';
+import LinearProgress, {
+  LinearProgressProps,
+} from '@material-ui/core/LinearProgress';
+import { Box, Typography } from '@material-ui/core';
+
+type Props = LinearProgressProps & {
+  duration: number;
+  started: boolean;
+};
+
+const BorderLinearProgress = withStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      borderRadius: 5,
+      height: 10,
+    },
+    colorPrimary: {
+      backgroundColor: '#7B66FC99',
+    },
+    bar: {
+      backgroundColor: theme.palette.primary.main,
+      borderRadius: 5,
+    },
+  })
+)(LinearProgress);
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+  },
+  progressBar: {
+    maxWidth: 200,
+    flexGrow: 1,
+    marginRight: theme.spacing(1),
+  },
+  label: {
+    minWidth: 35,
+  },
+}));
+
+const ProgressBar: React.FC<Props> = ({ duration, started }) => {
+  const classes = useStyles();
+  const [currentTime, setCurrentTime] = useState(0);
+  const value = (currentTime / duration) * 100;
+
+  useEffect(() => {
+    if (!started) {
+      return;
+    }
+
+    // Schedule timer
+    setCurrentTime(10);
+  }, [started]);
+
+  const formatTime = (time: number) => {
+    const minutes = Math.floor(time / 60)
+      .toString()
+      .padStart(1, '0');
+    const seconds = Math.floor(time % 60)
+      .toString()
+      .padStart(2, '0');
+    return `${minutes}:${seconds}`;
+  };
+
+  return (
+    <Box className={classes.root}>
+      <Box className={classes.progressBar}>
+        <BorderLinearProgress variant="determinate" value={value} />
+      </Box>
+      <Box className={classes.label}>
+        <Typography variant="body2" color="textSecondary">
+          {`${formatTime(currentTime)}/${formatTime(duration)}`}
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export default ProgressBar;

--- a/src/components/Solo/SoloRoomHeader.tsx
+++ b/src/components/Solo/SoloRoomHeader.tsx
@@ -11,6 +11,7 @@ import { useHistory } from 'react-router-dom';
 import { RoomView, RoomContext } from '../../contexts/RoomContext';
 import SettingsIcon from '../../icons/SettingsIcon';
 import useSong from '../../utils/useSong';
+import ProgressBar from '../ProgressBar';
 import RoomHeader from '../shared/RoomHeader';
 
 const useStyles = makeStyles(theme => ({
@@ -20,7 +21,6 @@ const useStyles = makeStyles(theme => ({
   settingIcon: {
     marginLeft: theme.spacing(1),
   },
-
   link: {
     color: '#0000EE',
   },
@@ -31,6 +31,10 @@ const useStyles = makeStyles(theme => ({
     position: 'absolute',
     left: '50%',
     transform: 'translate(-50%)',
+  },
+  progressBar: {
+    flexGrow: 1,
+    marginRight: theme.spacing(1),
   },
 }));
 
@@ -112,6 +116,9 @@ const SoloRoomHeader: React.FC<Props> = ({
       {backButton()}
       {centerComponents()}
       <Box component="span" className={classes.empty} />
+      <div className={classes.progressBar}>
+        {view === 'solo.play' && <ProgressBar duration={126} started={false} />}
+      </div>
       <IconButton edge="end" size="small" className={classes.settingIcon}>
         <SettingsIcon />
       </IconButton>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42093424/96743960-1976d480-13f7-11eb-8b6b-17e12e62170e.png)

It's a bit hard to make it look exactly the same as the mockup with material UI. 
If we use something similar to the video control bar, we wont be using their functionalities such as adjust the timings so it is a bit wasted