### PR TITLE
Fix bug when leaving game view before countdown ends

### DIFF
--- a/src/components/Countdown.tsx
+++ b/src/components/Countdown.tsx
@@ -1,0 +1,40 @@
+import { Typography } from '@material-ui/core';
+import React, { useContext, useEffect } from 'react';
+import { RoomContext } from './RoomContext';
+
+type Props = {
+  setIsPlaying: (flag: boolean) => void;
+  setTimeToStart: (timeToStart: number) => void;
+};
+
+const Countdown: React.FC<Props> = ({ setIsPlaying, setTimeToStart }) => {
+  const { timeToStart } = useContext(RoomContext);
+
+  useEffect(() => {
+    if (timeToStart <= 0) {
+      return;
+    }
+
+    const handler = setTimeout(() => {
+      if (timeToStart > 0) {
+        setTimeToStart(timeToStart - 1);
+      }
+      if (timeToStart === 1) {
+        setIsPlaying(true);
+      }
+    }, 1000);
+
+    return () => {
+      clearTimeout(handler);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [timeToStart]);
+
+  return (
+    <Typography variant="h1" align="center" color="primary">
+      {timeToStart}
+    </Typography>
+  );
+};
+
+export default Countdown;

--- a/src/components/SoloRoom.tsx
+++ b/src/components/SoloRoom.tsx
@@ -1,10 +1,4 @@
-import {
-  Box,
-  makeStyles,
-  Typography,
-  useMediaQuery,
-  useTheme,
-} from '@material-ui/core';
+import { Box, makeStyles, useMediaQuery, useTheme } from '@material-ui/core';
 import React, { useEffect, useState } from 'react';
 import songsAPI from '../api/songs';
 import { RoomInfo } from '../types/roomInfo';
@@ -17,6 +11,7 @@ import { getKeyboardMappingWithSpecificStart } from '../utils/getKeyboardShorcut
 import { useDimensions } from '../utils/useDimensions';
 import useSong from '../utils/useSong';
 import useWindowDimensions from '../utils/useWindowDimensions';
+import Countdown from './Countdown';
 import InteractivePiano from './InteractivePiano';
 import { RoomContext, RoomView } from './RoomContext';
 import SoloRoomHeader from './SoloRoomHeader';
@@ -69,21 +64,6 @@ const SoloRoom: React.FC = () => {
 
   const { piece } = roomState;
   const chosenSong = useSong(piece);
-
-  useEffect(() => {
-    if (timeToStart <= 0) {
-      return;
-    }
-
-    setTimeout(() => {
-      if (timeToStart > 0) {
-        setTimeToStart(timeToStart - 1);
-      }
-      if (timeToStart === 1) {
-        setIsPlaying(true);
-      }
-    }, 1000);
-  }, [timeToStart]);
 
   useEffect(() => {
     if (piece === undefined) return;
@@ -146,6 +126,7 @@ const SoloRoom: React.FC = () => {
           isPieceDownloaded={!!tracks}
           handleStart={() => {
             setTimeToStart(3);
+            setIsPlaying(false);
             setView('solo.play');
           }}
           tryPiano={() => setView('solo.try')}
@@ -159,6 +140,16 @@ const SoloRoom: React.FC = () => {
     //   show number countdown
     // if timeToStart is 0 and playing, show waterfall, music, etc.
     // if timeToStart is 0 and not playing, show the current stuff
+
+    if (view === 'solo.play' && timeToStart !== 0) {
+      return (
+        <Countdown
+          setIsPlaying={setIsPlaying}
+          setTimeToStart={setTimeToStart}
+        />
+      );
+    }
+
     if (isPlaying && tracks)
       return (
         <Waterfall
@@ -169,14 +160,6 @@ const SoloRoom: React.FC = () => {
           notes={tracks[0].notes}
         />
       );
-
-    if (view === 'solo.play' && timeToStart !== 0) {
-      return (
-        <Typography variant="h1" align="center" color="primary">
-          {timeToStart}
-        </Typography>
-      );
-    }
 
     return <></>;
   };


### PR DESCRIPTION
If you start a game, then return back to the song selection page, then start again, there will be some weird glitches. This happens due to uncleared timeouts and not resetting some state variables that are used to determine what to show.