### PR TITLE
Fix unnecessary rerendering of game view

### DIFF
--- a/src/components/Game/GameSmartPiano.tsx
+++ b/src/components/Game/GameSmartPiano.tsx
@@ -19,7 +19,7 @@ type Props = {
 const GameSmartPiano: React.FC<Props> = ({
   instrumentPlayer, // Unchanged
   keyWidth,
-  indexToNotesMap,
+  indexToNotesMap, // Unchanged
   didStopNote, // Unchanged
   didPlayNote, // Unchanged
   startTime,

--- a/src/components/Game/GameView.tsx
+++ b/src/components/Game/GameView.tsx
@@ -107,8 +107,6 @@ const GameView: React.FC<Props> = ({
     []
   );
 
-  console.log(indexToNotesMap[6]);
-
   const playerNotes = useMemo<Note[] | IndexedNote[]>(() => {
     if (showSmartPiano) {
       return getIndexedNotesFromNotes(normalPlayerNotes);
@@ -301,4 +299,4 @@ const GameView: React.FC<Props> = ({
   );
 };
 
-export default GameView;
+export default React.memo(GameView, () => true);

--- a/src/components/Piano/SmartPiano/SmartPiano.tsx
+++ b/src/components/Piano/SmartPiano/SmartPiano.tsx
@@ -35,13 +35,13 @@ type Props = {
 };
 
 const SmartPiano: React.FC<Props> = ({
-  instrumentPlayer,
+  instrumentPlayer, // Unchanged
   keyWidth,
   keyHeight,
-  indexToNotesMap,
-  didPlayNote = noOp,
-  didStopNote = noOp,
-  keyboardMap,
+  indexToNotesMap, // Unchanged
+  didPlayNote = noOp, // Unchanged
+  didStopNote = noOp, // Unchanged
+  keyboardMap, // Unchanged
   startTime,
 }) => {
   const numOfSmartKeys = 7;
@@ -295,4 +295,12 @@ const SmartPiano: React.FC<Props> = ({
   );
 };
 
-export default SmartPiano;
+function areEqual(prevProps: Props, nextProps: Props) {
+  return (
+    prevProps.keyWidth === nextProps.keyWidth &&
+    prevProps.keyHeight === nextProps.keyHeight &&
+    prevProps.startTime === nextProps.startTime
+  );
+}
+
+export default React.memo(SmartPiano, areEqual);

--- a/src/components/Piano/SmartPiano/SmartPianoKey.tsx
+++ b/src/components/Piano/SmartPiano/SmartPianoKey.tsx
@@ -1,5 +1,4 @@
-import React, { useContext, useState } from 'react';
-import { PlayerContext } from '../../../contexts/PlayerContext';
+import React, { useState } from 'react';
 import { PlayingNote } from '../types/playingNote';
 import './SmartPiano.css';
 
@@ -18,13 +17,12 @@ const SmartPianoKey: React.FC<Props> = ({
   index,
   keyWidth,
   keyHeight,
-  startPlayingNote,
-  stopPlayingNote,
-  keyboardShortcut,
+  startPlayingNote, // Unchanged
+  stopPlayingNote, // Unchanged
+  keyboardShortcut, // Unchanged
   useTouchEvents: useTouchscreen,
   playingNote,
 }) => {
-  const { me } = useContext(PlayerContext);
   const [useTouchEvents, setUseTouchEvents] = useState(useTouchscreen);
 
   const handleMouseDown = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -85,11 +83,7 @@ const SmartPianoKey: React.FC<Props> = ({
     if (playingNote.length === 0) {
       return '';
     } else {
-      if (playingNote[0].playerId === me) {
-        return 'smart-piano__key--playing-by-me';
-      } else {
-        return 'smart-piano__key--playing-by-others';
-      }
+      return 'smart-piano__key--playing-by-me';
     }
   };
 
@@ -107,4 +101,14 @@ const SmartPianoKey: React.FC<Props> = ({
   );
 };
 
-export default React.memo(SmartPianoKey);
+function areEqual(prevProps: Props, nextProps: Props) {
+  return (
+    prevProps.keyWidth === nextProps.keyWidth &&
+    prevProps.keyHeight === nextProps.keyHeight &&
+    prevProps.index === nextProps.index &&
+    prevProps.useTouchEvents === nextProps.useTouchEvents &&
+    prevProps.playingNote.length === nextProps.playingNote.length // For smart piano, only my playing notes are included
+  );
+}
+
+export default React.memo(SmartPianoKey, areEqual);


### PR DESCRIPTION
Use `React.Memo` to prevent unnecessary rerendering of game view
Although it is not entirely reliable according to React docs, but after profiling the page rerendering, according to the stats the game view is indeed not rerendering anymore after game start, it only gets rerendered 3 times because of the countdown

We have to carefully manage the dependencies with React.Memo, i.e. keep track of props that are changing over time and props that are never changing. Otherwise, it might lead to other page rendering issues


![image](https://user-images.githubusercontent.com/42093424/97548569-3e2c0700-1a0a-11eb-8806-ccba983589fb.png)
