### PR TITLE
Keep progress bar in view

### DIFF
--- a/src/components/Game/GameView.tsx
+++ b/src/components/Game/GameView.tsx
@@ -275,13 +275,11 @@ const GameView: React.FC<Props> = ({
 
   return (
     <div className={classes.root}>
-      {!gameEnd && (
-        <ProgressBar
-          startTime={startTime}
-          delayedStartTime={delayedStartTime}
-          songDuration={songDuration}
-        />
-      )}
+      <ProgressBar
+        startTime={startTime}
+        delayedStartTime={delayedStartTime}
+        songDuration={songDuration}
+      />
       <div ref={middleBoxRef} className={classes.middleBox}>
         <GameMiddleView
           timeToStart={timeToStart}


### PR DESCRIPTION
Not exactly addressing the cleanup, but kinda go around it instead.

Closes #78 

This happens because the library we're using actually fades out the progress bar once it reaches 100%. They use a setInterval within the library to do this, and there were no clearIntervals for these setIntervals if the LoadingBar was removed. This is why we saw those errors.

Since the library fades the bar out for us, we can keep it in view instead of removing it from view to achieve the same effect.